### PR TITLE
feat: remove punycode dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,6 @@
     "": {
       "version": "1.0.3",
       "license": "Apache-2.0",
-      "dependencies": {
-        "punycode": "^2.1.1"
-      },
       "devDependencies": {
         "@commitlint/cli": "^12.1.4",
         "@commitlint/config-conventional": "^12.1.4",
@@ -1279,9 +1276,9 @@
       }
     },
     "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.7.tgz",
-      "integrity": "sha512-BTIhocbPBSrRmHxOAJFtR18oLhxTtAFDAvL8hY1S3iU8k+E60W/YFs4jrixGzQjMpF4qPXxIQHcjVD9dz1C2QA==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -1354,9 +1351,9 @@
       }
     },
     "node_modules/@types/babel__core": {
-      "version": "7.1.14",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.14.tgz",
-      "integrity": "sha512-zGZJzzBUVDo/eV6KgbE0f0ZI7dInEYvo12Rb70uNQDshC3SkRMb67ja0GgRHZgAX3Za6rhaWlvbDO8rrGyAb1g==",
+      "version": "7.1.15",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.15.tgz",
+      "integrity": "sha512-bxlMKPDbY8x5h6HBwVzEOk2C8fb6SLfYQ5Jw3uBYuYF1lfWk/kbLd81la82vrIkBb0l+JdmrZaDikPrNxpS/Ew==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.1.0",
@@ -1367,18 +1364,18 @@
       }
     },
     "node_modules/@types/babel__generator": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.2.tgz",
-      "integrity": "sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.3.tgz",
+      "integrity": "sha512-/GWCmzJWqV7diQW54smJZzWbSFf4QYtF71WCKhcx6Ru/tFyQIY2eiiITcCAeuPbNSvT9YCGkVMqqvSk2Z0mXiA==",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.0.0"
       }
     },
     "node_modules/@types/babel__template": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.0.tgz",
-      "integrity": "sha512-NTPErx4/FiPCGScH7foPyr+/1Dkzkni+rHiYHHoTjvwou7AQzJkNeD60A9CXRy+ZEN2B1bggmkTMCDb+Mv5k+A==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.1.tgz",
+      "integrity": "sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.1.0",
@@ -1386,9 +1383,9 @@
       }
     },
     "node_modules/@types/babel__traverse": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.14.0.tgz",
-      "integrity": "sha512-IilJZ1hJBUZwMOVDNTdflOOLzJB/ZtljYVa7k3gEZN/jqIJIPkWHC6dvbX+DD2CwZDHB9wAKzZPzzqMIkW37/w==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.14.2.tgz",
+      "integrity": "sha512-K2waXdXBi2302XUdcHcR1jCeU0LL4TD9HRs/gk0N2Xvrht+G/BfJa4QObBQZfhMdxiCpV3COl5Nfq4uKTeTnJA==",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.3.0"
@@ -1444,34 +1441,27 @@
       }
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
-      "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.8.tgz",
+      "integrity": "sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg==",
       "dev": true
     },
-    "node_modules/@types/json5": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/@types/minimist": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.1.tgz",
-      "integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.0.0.tgz",
-      "integrity": "sha512-TmCW5HoZ2o2/z2EYi109jLqIaPIi9y/lc2LmDCWzuCi35bcaQ+OtUh6nwBiFK7SOu25FAU5+YKdqFZUwtqGSdg==",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.3.1.tgz",
+      "integrity": "sha512-N87VuQi7HEeRJkhzovao/JviiqKjDKMVKxKMfUvSKw+MbkbW8R0nA3fi/MQhhlxV2fQ+2ReM+/Nt4efdrJx3zA==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
+      "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
     },
     "node_modules/@types/parse-json": {
@@ -1481,9 +1471,9 @@
       "dev": true
     },
     "node_modules/@types/prettier": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.1.tgz",
-      "integrity": "sha512-NVkb4p4YjI8E3O6+1m8I+8JlMpFZwfSbPGdaw0wXuyPRTEz0SLKwBUWNSO7Maoi8tQMPC8JLZNWkrcKPI7/sLA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.2.tgz",
+      "integrity": "sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog==",
       "dev": true
     },
     "node_modules/@types/punycode": {
@@ -1698,9 +1688,9 @@
       }
     },
     "node_modules/acorn-jsx": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
-      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -2150,9 +2140,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001242",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001242.tgz",
-      "integrity": "sha512-KvNuZ/duufelMB3w2xtf9gEWCSxJwUgoxOx5b6ScLXC4kPc9xsczUVCPrQU26j5kOsHM4pSUL54tAZt5THQKug==",
+      "version": "1.0.30001243",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001243.tgz",
+      "integrity": "sha512-vNxw9mkTBtkmLFnJRv/2rhs1yufpDfCkBZexG3Y0xdOH2Z/eE/85E4Dl5j1YUN34nZVsSp6vVRFQRrez9wJMRA==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -2628,9 +2618,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.766",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.766.tgz",
-      "integrity": "sha512-u2quJ862q9reRKh/je3GXis3w38+RoXH1J9N3XjtsS6NzmUAosNsyZgUVFZPN/ZlJ3v6T0rTyZR3q/J5c6Sy5w==",
+      "version": "1.3.772",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.772.tgz",
+      "integrity": "sha512-X/6VRCXWALzdX+RjCtBU6cyg8WZgoxm9YA02COmDOiNJEZ59WkQggDbWZ4t/giHi/3GS+cvdrP6gbLISANAGYA==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -3521,9 +3511,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.6.tgz",
-      "integrity": "sha512-GnLuqj/pvQ7pX8/L4J84nijv6sAnlwvSDpMkJi9i7nPmPxGtRPkBSStfvDW5l6nMdX9VWe+pkKWFTgD+vF2QSQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
+      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -3620,9 +3610,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.0.tgz",
-      "integrity": "sha512-XprP7lDrVT+kE2c2YlfiV+IfS9zxukiIOvNamPNsImNhXadSsQEbosItdL9bUQlCZXR13SvPk20BjWSWLA7m4A==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.1.tgz",
+      "integrity": "sha512-OMQjaErSFHmHqZe+PSidH5n8j3O0F2DdnVh8JB4j4eUQ2k6KvB0qGfrKIhapvez5JerBbmWkaLYUYWISaESoXg==",
       "dev": true
     },
     "node_modules/form-data": {
@@ -3810,9 +3800,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.9.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.9.0.tgz",
-      "integrity": "sha512-74/FduwI/JaIrr1H8e71UbDE+5x7pIPs1C2rrwC52SszOo043CsWOZEMW7o2Y58xwm9b+0RBKDxY5n2sUpEFxA==",
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.10.0.tgz",
+      "integrity": "sha512-piHC3blgLGFjvOuMmWZX60f+na1lXFDhQXBf1UYp2fXPXqvEUbOhNwi6BsQ0bQishwedgnjkwv1d9zKf+MWw3g==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -6883,6 +6873,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -8014,29 +8005,15 @@
       }
     },
     "node_modules/tsconfig-paths": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
-      "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.10.1.tgz",
+      "integrity": "sha512-rETidPDgCpltxF7MjBZlAFPUHv5aHH2MymyPvh+vEyWAED4Eb/WeMbsnD/JDr4OKPOA1TssDHgIcpTN5Kh0p6Q==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@types/json5": "^0.0.29",
-        "json5": "^1.0.1",
+        "json5": "^2.2.0",
         "minimist": "^1.2.0",
         "strip-bom": "^3.0.0"
-      }
-    },
-    "node_modules/tsconfig-paths/node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
       }
     },
     "node_modules/tsconfig-paths/node_modules/strip-bom": {
@@ -9419,9 +9396,9 @@
       "dev": true
     },
     "@nodelib/fs.walk": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.7.tgz",
-      "integrity": "sha512-BTIhocbPBSrRmHxOAJFtR18oLhxTtAFDAvL8hY1S3iU8k+E60W/YFs4jrixGzQjMpF4qPXxIQHcjVD9dz1C2QA==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "dev": true,
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -9474,9 +9451,9 @@
       "dev": true
     },
     "@types/babel__core": {
-      "version": "7.1.14",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.14.tgz",
-      "integrity": "sha512-zGZJzzBUVDo/eV6KgbE0f0ZI7dInEYvo12Rb70uNQDshC3SkRMb67ja0GgRHZgAX3Za6rhaWlvbDO8rrGyAb1g==",
+      "version": "7.1.15",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.15.tgz",
+      "integrity": "sha512-bxlMKPDbY8x5h6HBwVzEOk2C8fb6SLfYQ5Jw3uBYuYF1lfWk/kbLd81la82vrIkBb0l+JdmrZaDikPrNxpS/Ew==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -9487,18 +9464,18 @@
       }
     },
     "@types/babel__generator": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.2.tgz",
-      "integrity": "sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.3.tgz",
+      "integrity": "sha512-/GWCmzJWqV7diQW54smJZzWbSFf4QYtF71WCKhcx6Ru/tFyQIY2eiiITcCAeuPbNSvT9YCGkVMqqvSk2Z0mXiA==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
     },
     "@types/babel__template": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.0.tgz",
-      "integrity": "sha512-NTPErx4/FiPCGScH7foPyr+/1Dkzkni+rHiYHHoTjvwou7AQzJkNeD60A9CXRy+ZEN2B1bggmkTMCDb+Mv5k+A==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.1.tgz",
+      "integrity": "sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -9506,9 +9483,9 @@
       }
     },
     "@types/babel__traverse": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.14.0.tgz",
-      "integrity": "sha512-IilJZ1hJBUZwMOVDNTdflOOLzJB/ZtljYVa7k3gEZN/jqIJIPkWHC6dvbX+DD2CwZDHB9wAKzZPzzqMIkW37/w==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.14.2.tgz",
+      "integrity": "sha512-K2waXdXBi2302XUdcHcR1jCeU0LL4TD9HRs/gk0N2Xvrht+G/BfJa4QObBQZfhMdxiCpV3COl5Nfq4uKTeTnJA==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
@@ -9564,34 +9541,27 @@
       }
     },
     "@types/json-schema": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
-      "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.8.tgz",
+      "integrity": "sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg==",
       "dev": true
     },
-    "@types/json5": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
-      "dev": true,
-      "peer": true
-    },
     "@types/minimist": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.1.tgz",
-      "integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
       "dev": true
     },
     "@types/node": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.0.0.tgz",
-      "integrity": "sha512-TmCW5HoZ2o2/z2EYi109jLqIaPIi9y/lc2LmDCWzuCi35bcaQ+OtUh6nwBiFK7SOu25FAU5+YKdqFZUwtqGSdg==",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.3.1.tgz",
+      "integrity": "sha512-N87VuQi7HEeRJkhzovao/JviiqKjDKMVKxKMfUvSKw+MbkbW8R0nA3fi/MQhhlxV2fQ+2ReM+/Nt4efdrJx3zA==",
       "dev": true
     },
     "@types/normalize-package-data": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
+      "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
     },
     "@types/parse-json": {
@@ -9601,9 +9571,9 @@
       "dev": true
     },
     "@types/prettier": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.1.tgz",
-      "integrity": "sha512-NVkb4p4YjI8E3O6+1m8I+8JlMpFZwfSbPGdaw0wXuyPRTEz0SLKwBUWNSO7Maoi8tQMPC8JLZNWkrcKPI7/sLA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.2.tgz",
+      "integrity": "sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog==",
       "dev": true
     },
     "@types/punycode": {
@@ -9738,9 +9708,9 @@
       }
     },
     "acorn-jsx": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
-      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "requires": {}
     },
@@ -10074,9 +10044,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001242",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001242.tgz",
-      "integrity": "sha512-KvNuZ/duufelMB3w2xtf9gEWCSxJwUgoxOx5b6ScLXC4kPc9xsczUVCPrQU26j5kOsHM4pSUL54tAZt5THQKug==",
+      "version": "1.0.30001243",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001243.tgz",
+      "integrity": "sha512-vNxw9mkTBtkmLFnJRv/2rhs1yufpDfCkBZexG3Y0xdOH2Z/eE/85E4Dl5j1YUN34nZVsSp6vVRFQRrez9wJMRA==",
       "dev": true
     },
     "chalk": {
@@ -10446,9 +10416,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.766",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.766.tgz",
-      "integrity": "sha512-u2quJ862q9reRKh/je3GXis3w38+RoXH1J9N3XjtsS6NzmUAosNsyZgUVFZPN/ZlJ3v6T0rTyZR3q/J5c6Sy5w==",
+      "version": "1.3.772",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.772.tgz",
+      "integrity": "sha512-X/6VRCXWALzdX+RjCtBU6cyg8WZgoxm9YA02COmDOiNJEZ59WkQggDbWZ4t/giHi/3GS+cvdrP6gbLISANAGYA==",
       "dev": true
     },
     "emittery": {
@@ -11102,9 +11072,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.6.tgz",
-      "integrity": "sha512-GnLuqj/pvQ7pX8/L4J84nijv6sAnlwvSDpMkJi9i7nPmPxGtRPkBSStfvDW5l6nMdX9VWe+pkKWFTgD+vF2QSQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
+      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -11183,9 +11153,9 @@
       }
     },
     "flatted": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.0.tgz",
-      "integrity": "sha512-XprP7lDrVT+kE2c2YlfiV+IfS9zxukiIOvNamPNsImNhXadSsQEbosItdL9bUQlCZXR13SvPk20BjWSWLA7m4A==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.1.tgz",
+      "integrity": "sha512-OMQjaErSFHmHqZe+PSidH5n8j3O0F2DdnVh8JB4j4eUQ2k6KvB0qGfrKIhapvez5JerBbmWkaLYUYWISaESoXg==",
       "dev": true
     },
     "form-data": {
@@ -11324,9 +11294,9 @@
       }
     },
     "globals": {
-      "version": "13.9.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.9.0.tgz",
-      "integrity": "sha512-74/FduwI/JaIrr1H8e71UbDE+5x7pIPs1C2rrwC52SszOo043CsWOZEMW7o2Y58xwm9b+0RBKDxY5n2sUpEFxA==",
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.10.0.tgz",
+      "integrity": "sha512-piHC3blgLGFjvOuMmWZX60f+na1lXFDhQXBf1UYp2fXPXqvEUbOhNwi6BsQ0bQishwedgnjkwv1d9zKf+MWw3g==",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
@@ -13631,7 +13601,8 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "q": {
       "version": "1.5.1",
@@ -14490,28 +14461,17 @@
       }
     },
     "tsconfig-paths": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
-      "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.10.1.tgz",
+      "integrity": "sha512-rETidPDgCpltxF7MjBZlAFPUHv5aHH2MymyPvh+vEyWAED4Eb/WeMbsnD/JDr4OKPOA1TssDHgIcpTN5Kh0p6Q==",
       "dev": true,
       "peer": true,
       "requires": {
-        "@types/json5": "^0.0.29",
-        "json5": "^1.0.1",
+        "json5": "^2.2.0",
         "minimist": "^1.2.0",
         "strip-bom": "^3.0.0"
       },
       "dependencies": {
-        "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        },
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "/dist"
   ],
   "scripts": {
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsc",
     "test": "jest",
     "coverage": "jest --coverage",
     "build": "npm run clean && tsc && rollup -c",
@@ -60,14 +60,21 @@
     "tslib": "^2.3.0",
     "typescript": "^4.3.5"
   },
-  "dependencies": {
-    "punycode": "^2.1.1"
-  },
   "lint-staged": {
     "**/*.ts": "eslint --fix"
   },
   "jest": {
-    "preset": "ts-jest/presets/default-esm",
-    "testEnvironment": "node"
+    "projects": [
+      {
+        "displayName": "node",
+        "preset": "ts-jest/presets/default-esm",
+        "testEnvironment": "node"
+      },
+      {
+        "displayName": "jsdom",
+        "preset": "ts-jest/presets/default-esm",
+        "testEnvironment": "jsdom"
+      }
+    ]
   }
 }

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -28,7 +28,7 @@ const config = [
       },
     ],
     plugins: [typescript()],
-    external: ['punycode/'],
+    external: ['url'],
   },
   {
     input: './tsc/types/index.d.ts',

--- a/src/helpers/toASCII.ts
+++ b/src/helpers/toASCII.ts
@@ -1,0 +1,38 @@
+/**
+ * Use browser's punycode implementation to convert string for validation
+ * @private
+ * @param domain input to convert to punycode
+ * @returns IDNA2008 representation of domain
+ */
+const browserToASCII = async (domain: string): Promise<string> => {
+  const a = document.createElement('a');
+  a.href = 'http://' + domain;
+  return a.hostname;
+};
+
+/**
+ * Use nodejs punycode implementation to convert string for validation
+ * @private
+ * @param domain input to convert to punycode
+ * @returns IDNA2008 representaiton of domain
+ */
+const domainToASCII = async (domain: string): Promise<string> => {
+  const url = await import('url');
+  return url.domainToASCII(domain);
+};
+
+/**
+ * Convert a domain to punycode
+ * @private
+ * @param domain input to convert to punycode
+ * @returns IDNA2008 representation of domain
+ */
+const toASCII = async (domain: string): Promise<string> => {
+  if (typeof window !== 'undefined' && typeof window.document !== 'undefined') {
+    return await browserToASCII(domain);
+  } else {
+    return await domainToASCII(domain);
+  }
+};
+
+export default toASCII;

--- a/src/isDomain.ts
+++ b/src/isDomain.ts
@@ -1,4 +1,4 @@
-import { toASCII } from 'punycode/';
+import toASCII from './helpers/toASCII';
 import isTld from './isTld';
 
 const domainLabelRegex = '[a-zA-Z0-9](?:[a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?';
@@ -15,14 +15,17 @@ const domainRegex = new RegExp(
  * @param allowLocal - should local addresses be considered valid?
  * @returns true if the parameter is a valid domain name
  */
-const isDomain = (domain: string, allowLocal = false): boolean => {
+const isDomain = async (
+  domain: string,
+  allowLocal = false,
+): Promise<boolean> => {
   if (!domain) {
     return false;
   }
 
-  domain = toASCII(domain);
+  domain = await toASCII(domain);
 
-  if (domain.length > 253) {
+  if (!domain || domain.length > 253) {
     return false;
   }
 

--- a/src/isTld.ts
+++ b/src/isTld.ts
@@ -1,10 +1,10 @@
-import { toASCII } from 'punycode/';
 import {
   countryCodeTlds,
   genericTlds,
   infrastructureTlds,
   localTlds,
 } from './constants/tlds';
+import toASCII from './helpers/toASCII';
 
 /**
  * Removes leading dot from string
@@ -82,12 +82,12 @@ export const isLocalTld = (lTld: string): boolean => {
  * @param allowLocal - whether local TLDs like ".localdomain" are allowed
  * @returns true if tld is a valid TLD, otherwise false
  */
-const isTld = (tld: string, allowLocal = false): boolean => {
+const isTld = async (tld: string, allowLocal = false): Promise<boolean> => {
   if (!tld) {
     return false;
   }
 
-  tld = toASCII(tld);
+  tld = await toASCII(chompLeadingDot(tld));
 
   if (allowLocal && isLocalTld(tld)) {
     return true;

--- a/test/helpers/toASCII.test.ts
+++ b/test/helpers/toASCII.test.ts
@@ -1,0 +1,9 @@
+import toASCII from '../../src/helpers/toASCII';
+
+describe('toASCII', () => {
+  it('should convert unicode to punycode', async () => {
+    expect(toASCII('www.b\u00fccher.ch')).resolves.toBe('www.xn--bcher-kva.ch');
+    expect(toASCII('президент.рф')).resolves.toBe('xn--d1abbgf6aiiy.xn--p1ai');
+    expect(toASCII('www.\uFFFD.ch')).resolves.toBe('');
+  });
+});

--- a/test/isDomain.test.ts
+++ b/test/isDomain.test.ts
@@ -1,84 +1,84 @@
 import isDomain from '../src/isDomain';
 
 describe('domain validator', () => {
-  it("should pass Apache's DomainValidatorTest#testValidDomains", () => {
-    expect(isDomain('apache.org')).toBeTruthy();
-    expect(isDomain('www.google.com')).toBeTruthy();
+  it("should pass Apache's DomainValidatorTest#testValidDomains", async () => {
+    expect(isDomain('apache.org')).resolves.toBeTruthy();
+    expect(isDomain('www.google.com')).resolves.toBeTruthy();
 
-    expect(isDomain('test-domain.com')).toBeTruthy();
-    expect(isDomain('test---domain.com')).toBeTruthy();
-    expect(isDomain('test-d-o-m-a-i-n.com')).toBeTruthy();
-    expect(isDomain('as.uk')).toBeTruthy(); // two-letter domain label
+    expect(isDomain('test-domain.com')).resolves.toBeTruthy();
+    expect(isDomain('test---domain.com')).resolves.toBeTruthy();
+    expect(isDomain('test-d-o-m-a-i-n.com')).resolves.toBeTruthy();
+    expect(isDomain('as.uk')).resolves.toBeTruthy(); // two-letter domain label
 
-    expect(isDomain('ApAchE.Org')).toBeTruthy(); // case-insensitive
+    expect(isDomain('ApAchE.Org')).resolves.toBeTruthy(); // case-insensitive
 
-    expect(isDomain('z.com')).toBeTruthy(); // single-character domain label
+    expect(isDomain('z.com')).resolves.toBeTruthy(); // single-character domain label
 
-    expect(isDomain('i.have.an-example.domain.name')).toBeTruthy();
+    expect(isDomain('i.have.an-example.domain.name')).resolves.toBeTruthy();
   });
 
-  it("should pass Apache's DomainValidatorTest#testInvalidDomains", () => {
-    expect(isDomain('.org')).toBeFalsy(); // bare TLD
-    expect(isDomain(' apache.org ')).toBeFalsy(); // domain name with spaces
-    expect(isDomain('apa che.org')).toBeFalsy(); // domain name containing spaces
-    expect(isDomain('-testdomain.name')).toBeFalsy(); // domain name starting with dash
-    expect(isDomain('testdomain-.name')).toBeFalsy(); // domain name ending with dash
-    expect(isDomain('---c.com')).toBeFalsy(); // domain name starting with multiple dashes
-    expect(isDomain('c--.com')).toBeFalsy(); // domain name ending with multiple dashes
-    expect(isDomain('apache.rog')).toBeFalsy(); // domain name with invalid TLD
+  it("should pass Apache's DomainValidatorTest#testInvalidDomains", async () => {
+    expect(isDomain('.org')).resolves.toBeFalsy(); // bare TLD
+    expect(isDomain(' apache.org ')).resolves.toBeFalsy(); // domain name with spaces
+    expect(isDomain('apa che.org')).resolves.toBeFalsy(); // domain name containing spaces
+    expect(isDomain('-testdomain.name')).resolves.toBeFalsy(); // domain name starting with dash
+    expect(isDomain('testdomain-.name')).resolves.toBeFalsy(); // domain name ending with dash
+    expect(isDomain('---c.com')).resolves.toBeFalsy(); // domain name starting with multiple dashes
+    expect(isDomain('c--.com')).resolves.toBeFalsy(); // domain name ending with multiple dashes
+    expect(isDomain('apache.rog')).resolves.toBeFalsy(); // domain name with invalid TLD
 
-    expect(isDomain('http://www.apache.org')).toBeFalsy(); // URL
-    expect(isDomain(' ')).toBeFalsy(); // Empty string
-    expect(isDomain(null)).toBeFalsy(); // null
+    expect(isDomain('http://www.apache.org')).resolves.toBeFalsy(); // URL
+    expect(isDomain(' ')).resolves.toBeFalsy(); // Empty string
+    expect(isDomain(null)).resolves.toBeFalsy(); // null
   });
 
-  it("should pass Apache's DomainValidatorTest#testAllowLocal", () => {
+  it("should pass Apache's DomainValidatorTest#testAllowLocal", async () => {
     // Default won't allow local
-    expect(isDomain('localhost.localdomain')).toBeFalsy();
-    expect(isDomain('localhost')).toBeFalsy();
+    expect(isDomain('localhost.localdomain')).resolves.toBeFalsy();
+    expect(isDomain('localhost')).resolves.toBeFalsy();
 
     // But it may be requested
-    expect(isDomain('localhost.localdomain', true)).toBeTruthy();
-    expect(isDomain('localhost', true)).toBeTruthy();
-    expect(isDomain('hostname', true)).toBeTruthy();
-    expect(isDomain('machinename', true)).toBeTruthy();
+    expect(isDomain('localhost.localdomain', true)).resolves.toBeTruthy();
+    expect(isDomain('localhost', true)).resolves.toBeTruthy();
+    expect(isDomain('hostname', true)).resolves.toBeTruthy();
+    expect(isDomain('machinename', true)).resolves.toBeTruthy();
 
     // Check the localhost one with a few others
-    expect(isDomain('apache.org', true)).toBeTruthy();
-    expect(isDomain(' apache.org ', true)).toBeFalsy();
+    expect(isDomain('apache.org', true)).resolves.toBeTruthy();
+    expect(isDomain(' apache.org ', true)).resolves.toBeFalsy();
   });
 
-  it("should pass Apache's DomainValidatorTest#testIDN", () => {
-    expect(isDomain('www.xn--bcher-kva.ch')).toBeTruthy();
+  it("should pass Apache's DomainValidatorTest#testIDN", async () => {
+    expect(isDomain('www.xn--bcher-kva.ch')).resolves.toBeTruthy();
 
-    expect(isDomain('www.b\u00fccher.ch')).toBeTruthy();
-    expect(isDomain('xn--d1abbgf6aiiy.xn--p1ai')).toBeTruthy();
-    expect(isDomain('президент.рф')).toBeTruthy();
-    // expect(isDomain('www.\uFFFD.ch')).toBeFalsy(); // punycode library bug
+    expect(isDomain('www.b\u00fccher.ch')).resolves.toBeTruthy();
+    expect(isDomain('xn--d1abbgf6aiiy.xn--p1ai')).resolves.toBeTruthy();
+    expect(isDomain('президент.рф')).resolves.toBeTruthy();
+    expect(isDomain('www.\uFFFD.ch')).resolves.toBeFalsy();
   });
 
-  it("should pass Apache's DomainValidatorTest#testRFC2396domainlabel", () => {
-    expect(isDomain('a.ch')).toBeTruthy();
-    expect(isDomain('9.ch')).toBeTruthy();
-    expect(isDomain('az.ch')).toBeTruthy();
-    expect(isDomain('09.ch')).toBeTruthy();
-    expect(isDomain('9-1.ch')).toBeTruthy();
-    expect(isDomain('91-.ch')).toBeFalsy();
-    expect(isDomain('-.ch')).toBeFalsy();
+  it("should pass Apache's DomainValidatorTest#testRFC2396domainlabel", async () => {
+    expect(isDomain('a.ch')).resolves.toBeTruthy();
+    expect(isDomain('9.ch')).resolves.toBeTruthy();
+    expect(isDomain('az.ch')).resolves.toBeTruthy();
+    expect(isDomain('09.ch')).resolves.toBeTruthy();
+    expect(isDomain('9-1.ch')).resolves.toBeTruthy();
+    expect(isDomain('91-.ch')).resolves.toBeFalsy();
+    expect(isDomain('-.ch')).resolves.toBeFalsy();
   });
 
-  it("should pass Apache's DomainValidatorTest#testValidator297", () => {
-    expect(isDomain('xn--d1abbgf6aiiy.xn--p1ai')).toBeTruthy();
+  it("should pass Apache's DomainValidatorTest#testValidator297", async () => {
+    expect(isDomain('xn--d1abbgf6aiiy.xn--p1ai')).resolves.toBeTruthy();
   });
 
-  it("should pass Apache's DomainValidatorTest#testValidator306", () => {
+  it("should pass Apache's DomainValidatorTest#testValidator306", async () => {
     const longString =
       'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz0123456789A';
 
     expect(longString.length).toBe(63);
 
-    expect(isDomain(longString + '.com')).toBeTruthy();
-    expect(isDomain(longString + 'x.com')).toBeFalsy();
+    expect(isDomain(longString + '.com')).resolves.toBeTruthy();
+    expect(isDomain(longString + 'x.com')).resolves.toBeFalsy();
 
     const longDomain =
       longString +
@@ -91,7 +91,7 @@ describe('domain validator', () => {
 
     expect(longDomain.length).toBe(249);
 
-    expect(isDomain(longDomain + '.com'));
-    expect(isDomain(longDomain + 'x.com'));
+    expect(isDomain(longDomain + '.com')).resolves.toBeTruthy();
+    expect(isDomain(longDomain + 'x.com')).resolves.toBeFalsy();
   });
 });

--- a/test/isEmail.test.ts
+++ b/test/isEmail.test.ts
@@ -1,303 +1,207 @@
 import isEmail from '../src/isEmail';
 
 describe('email validator', () => {
-  it("should pass Apache's EmailValidatorTest#testEmail", () => {
-    expect(isEmail('jsmith@apache.org')).toBeTruthy();
+  it("should pass Apache's EmailValidatorTest#testEmail", async () => {
+    expect(isEmail('jsmith@apache.org')).resolves.toBeTruthy();
   });
 
-  it("should pass Apache's EmailValidatorTest#testEmailWithNumericAddress", () => {
-    expect(isEmail('someone@[216.109.118.76]')).toBeTruthy();
-    expect(isEmail('someone@yahoo.com')).toBeTruthy();
+  it("should pass Apache's EmailValidatorTest#testEmailWithNumericAddress", async () => {
+    expect(isEmail('someone@[216.109.118.76]')).resolves.toBeTruthy();
+    expect(isEmail('someone@yahoo.com')).resolves.toBeTruthy();
   });
 
-  it("should pass Apache's EmailValidatorTest#testEmailExtension", () => {
-    expect(isEmail('jsmith@apache.org')).toBeTruthy();
-    expect(isEmail('jsmith@apache.com')).toBeTruthy();
-    expect(isEmail('jsmith@apache.net')).toBeTruthy();
-    expect(isEmail('jsmith@apache.info')).toBeTruthy();
-    expect(isEmail('jsmith@apache.')).toBeFalsy();
-    expect(isEmail('jsmith@apache.c')).toBeFalsy();
-    expect(isEmail('someone@yahoo.museum')).toBeTruthy();
-    expect(isEmail('someone@yahoo.mu-seum')).toBeFalsy();
+  it("should pass Apache's EmailValidatorTest#testEmailExtension", async () => {
+    expect(isEmail('jsmith@apache.org')).resolves.toBeTruthy();
+    expect(isEmail('jsmith@apache.com')).resolves.toBeTruthy();
+    expect(isEmail('jsmith@apache.net')).resolves.toBeTruthy();
+    expect(isEmail('jsmith@apache.info')).resolves.toBeTruthy();
+    expect(isEmail('jsmith@apache.')).resolves.toBeFalsy();
+    expect(isEmail('jsmith@apache.c')).resolves.toBeFalsy();
+    expect(isEmail('someone@yahoo.museum')).resolves.toBeTruthy();
+    expect(isEmail('someone@yahoo.mu-seum')).resolves.toBeFalsy();
   });
 
-  it("should pass Apache's EmailValidatorTest#testEmailWithDash", () => {
-    expect(isEmail('andy.noble@data-workshop.com')).toBeTruthy();
-    expect(isEmail('andy-noble@data-workshop.-com')).toBeFalsy();
-    expect(isEmail('andy-noble@data-workshop.c-om')).toBeFalsy();
-    expect(isEmail('andy-noble@data-workshop.co-m')).toBeFalsy();
+  it("should pass Apache's EmailValidatorTest#testEmailWithDash", async () => {
+    expect(isEmail('andy.noble@data-workshop.com')).resolves.toBeTruthy();
+    expect(isEmail('andy-noble@data-workshop.-com')).resolves.toBeFalsy();
+    expect(isEmail('andy-noble@data-workshop.c-om')).resolves.toBeFalsy();
+    expect(isEmail('andy-noble@data-workshop.co-m')).resolves.toBeFalsy();
   });
 
-  it("should pass Apache's EmailValidatorTest#testEmailWithDotEnd", () => {
-    expect(isEmail('andy.noble@data-workshop.com.')).toBeFalsy();
+  it("should pass Apache's EmailValidatorTest#testEmailWithDotEnd", async () => {
+    expect(isEmail('andy.noble@data-workshop.com.')).resolves.toBeFalsy();
   });
 
-  it("should pass Apache's EmailValidatorTest#testEmailWithBogusCharacter", () => {
-    // expect(isEmail('andy.noble@\u008fdata-workshop.com')).toBeFalsy(); // punycode library bug
+  it("should pass Apache's EmailValidatorTest#testEmailWithBogusCharacter", async () => {
+    expect(isEmail('andy.noble@\u008fdata-workshop.com')).resolves.toBeFalsy();
 
     // The ' characteris valid in an email username.
-    expect(isEmail("andy.o'reilly@data-workshop.com")).toBeTruthy();
+    expect(isEmail("andy.o'reilly@data-workshop.com")).resolves.toBeTruthy();
 
     // But not in the domain name.
-    expect(isEmail("andy@o'reilly.data-workshop.com")).toBeFalsy();
+    expect(isEmail("andy@o'reilly.data-workshop.com")).resolves.toBeFalsy();
 
     // The + character is valid in an email username.
-    expect(isEmail('foo+bar@i.am.not.in.us.example.com')).toBeTruthy();
+    expect(isEmail('foo+bar@i.am.not.in.us.example.com')).resolves.toBeTruthy();
 
     // But not in the domain name
-    expect(isEmail('foo+bar@example+3.com')).toBeFalsy();
+    expect(isEmail('foo+bar@example+3.com')).resolves.toBeFalsy();
 
     // Domains iwth only special characters aren't allowed (VALIDATOR-286)
-    expect(isEmail('test@%*.com')).toBeFalsy();
-    expect(isEmail('test@^&#.com')).toBeFalsy();
+    expect(isEmail('test@%*.com')).resolves.toBeFalsy();
+    expect(isEmail('test@^&#.com')).resolves.toBeFalsy();
   });
 
-  it("should pass Apache's EmailValidatorTest#testVALIDATOR_315", () => {
-    expect(isEmail('me@at&t.net')).toBeFalsy();
-    expect(isEmail('me@att.net')).toBeTruthy(); // Make sure TLD is not the cause of the failure
+  it("should pass Apache's EmailValidatorTest#testVALIDATOR_315", async () => {
+    expect(isEmail('me@at&t.net')).resolves.toBeFalsy();
+    expect(isEmail('me@att.net')).resolves.toBeTruthy(); // Make sure TLD is not the cause of the failure
   });
 
-  it("should pass Apache's EmailValidatorTest#testVALIDATOR_278", () => {
-    expect(isEmail('someone@-test.com')).toBeFalsy(); // hostname starts with a dash/hyphen
-    expect(isEmail('someone@test-.com')).toBeFalsy(); // hostname ends iwth a dash-hyphen
+  it("should pass Apache's EmailValidatorTest#testVALIDATOR_278", async () => {
+    expect(isEmail('someone@-test.com')).resolves.toBeFalsy(); // hostname starts with a dash/hyphen
+    expect(isEmail('someone@test-.com')).resolves.toBeFalsy(); // hostname ends iwth a dash-hyphen
   });
 
-  it("should pass Apache's EmailValidatorTest#testValidator235", () => {
-    expect(isEmail('someone@xn--d1abbgf6aiiy.xn--p1ai')).toBeTruthy();
-    expect(isEmail('someone@президент.рф')).toBeTruthy();
-    expect(isEmail('someone@www.b\u00fccher.ch')).toBeTruthy();
-    // expect(isEmail('someone@www.\uFFFD.ch')).toBeFalsy(); // punycode library bug
-    expect(isEmail('someone@www.b\u00fccher.ch')).toBeTruthy();
-    // expect(isEmail('someone@www.\uFFFD.ch')).toBeFalsy(); // punycode library bug
+  it("should pass Apache's EmailValidatorTest#testValidator235", async () => {
+    expect(isEmail('someone@xn--d1abbgf6aiiy.xn--p1ai')).resolves.toBeTruthy();
+    expect(isEmail('someone@президент.рф')).resolves.toBeTruthy();
+    expect(isEmail('someone@www.b\u00fccher.ch')).resolves.toBeTruthy();
+    expect(isEmail('someone@www.\uFFFD.ch')).resolves.toBeFalsy();
   });
 
-  it("should pass Apache's EmailValidatorTest#testEmailWithCommas", () => {
-    expect(isEmail('jowblow@apa,che.org')).toBeFalsy();
-    expect(isEmail('jowblow@apache.o,rg')).toBeFalsy();
-    expect(isEmail('jowblow@apache,org')).toBeFalsy();
+  it("should pass Apache's EmailValidatorTest#testEmailWithCommas", async () => {
+    expect(isEmail('jowblow@apa,che.org')).resolves.toBeFalsy();
+    expect(isEmail('jowblow@apache.o,rg')).resolves.toBeFalsy();
+    expect(isEmail('jowblow@apache,org')).resolves.toBeFalsy();
   });
 
-  it("should pass Apache's EmailValidatorTest#testEmailWithSpaces", () => {
-    expect(isEmail('joeblow @apache.org')).toBeFalsy();
-    expect(isEmail('joeblow@ apache.org')).toBeFalsy();
-    expect(isEmail(' joeblow@apache.org')).toBeFalsy();
-    expect(isEmail('joeblow@apache.org ')).toBeFalsy();
-    expect(isEmail('joe blow@apache.org')).toBeFalsy();
-    expect(isEmail('joeblow@apa che.org')).toBeFalsy();
-    expect(isEmail('"joeblow "@apache.org')).toBeTruthy();
-    expect(isEmail('" joeblow"@apache.org')).toBeTruthy();
-    expect(isEmail('" joeblow "@apache.org')).toBeTruthy();
+  it("should pass Apache's EmailValidatorTest#testEmailWithSpaces", async () => {
+    expect(isEmail('joeblow @apache.org')).resolves.toBeFalsy();
+    expect(isEmail('joeblow@ apache.org')).resolves.toBeFalsy();
+    expect(isEmail(' joeblow@apache.org')).resolves.toBeFalsy();
+    expect(isEmail('joeblow@apache.org ')).resolves.toBeFalsy();
+    expect(isEmail('joe blow@apache.org')).resolves.toBeFalsy();
+    expect(isEmail('joeblow@apa che.org')).resolves.toBeFalsy();
+    expect(isEmail('"joeblow "@apache.org')).resolves.toBeTruthy();
+    expect(isEmail('" joeblow"@apache.org')).resolves.toBeTruthy();
+    expect(isEmail('" joeblow "@apache.org')).resolves.toBeTruthy();
   });
 
-  it("should pass Apache's EmailValidatorTest#testEmailWithControlChars", () => {
+  it("should pass Apache's EmailValidatorTest#testEmailWithControlChars", async () => {
     for (let c = 0; c < 32; c++) {
       expect(
         isEmail('foo' + String.fromCharCode(c) + 'bar@domain.com'),
-      ).toBeFalsy();
+      ).resolves.toBeFalsy();
     }
 
     expect(
       isEmail('foo' + String.fromCharCode(127) + 'bar@domain.com'),
-    ).toBeFalsy();
+    ).resolves.toBeFalsy();
   });
 
-  it("should pass Apache's EmailValidatorTest#testEmailLocalhost", () => {
-    expect(isEmail('joe@localhost.localdomain', true)).toBeTruthy();
-    expect(isEmail('joe@localhost', true)).toBeTruthy();
+  it("should pass Apache's EmailValidatorTest#testEmailLocalhost", async () => {
+    expect(isEmail('joe@localhost.localdomain', true)).resolves.toBeTruthy();
+    expect(isEmail('joe@localhost', true)).resolves.toBeTruthy();
 
-    expect(isEmail('joe@localhost.localdomain')).toBeFalsy();
-    expect(isEmail('joe@localhost')).toBeFalsy();
+    expect(isEmail('joe@localhost.localdomain')).resolves.toBeFalsy();
+    expect(isEmail('joe@localhost')).resolves.toBeFalsy();
   });
 
-  it("should pass Apache's EmailValidatorTest#testEmailWithSlashes", () => {
-    expect(isEmail('joe!/blow@apache.org')).toBeTruthy();
-    expect(isEmail('joe@ap/ache.org')).toBeFalsy();
-    expect(isEmail('joe@apac!he.org')).toBeFalsy();
+  it("should pass Apache's EmailValidatorTest#testEmailWithSlashes", async () => {
+    expect(isEmail('joe!/blow@apache.org')).resolves.toBeTruthy();
+    expect(isEmail('joe@ap/ache.org')).resolves.toBeFalsy();
+    expect(isEmail('joe@apac!he.org')).resolves.toBeFalsy();
   });
 
-  it("should pass Apache's EmailValidatorTest#testEmailUserName", () => {
-    expect(isEmail('joe1blow@apache.org')).toBeTruthy();
-    expect(isEmail('joe$blow@apache.org')).toBeTruthy();
-    expect(isEmail('joe-@apache.org')).toBeTruthy();
-    expect(isEmail('joe_@apache.org')).toBeTruthy();
-    expect(isEmail('joe+@apache.org')).toBeTruthy(); // + is valid unquoted
-    expect(isEmail('joe!@apache.org')).toBeTruthy(); // ! is valid unquoted
-    expect(isEmail('joe*@apache.org')).toBeTruthy(); // * is valid unquoted
-    expect(isEmail("joe'@apache.org")).toBeTruthy(); // ' is valid unquoted
-    expect(isEmail('joe%45@apache.org')).toBeTruthy(); // % is valid unquoted
-    expect(isEmail('joe?@apache.org')).toBeTruthy(); // ? is valid unquoted
-    expect(isEmail('joe&@apache.org')).toBeTruthy(); // & ditto
-    expect(isEmail('joe=@apache.org')).toBeTruthy(); // = ditto
-    expect(isEmail('+joe@apache.org')).toBeTruthy(); // + is valid unquoted
-    expect(isEmail('!joe@apache.org')).toBeTruthy(); // ! is valid unquoted
-    expect(isEmail('*joe@apache.org')).toBeTruthy(); // * is valid unquoted
-    expect(isEmail("'joe@apache.org")).toBeTruthy(); // ' is valid unquoted
-    expect(isEmail('%joe45@apache.org')).toBeTruthy(); // % is valid unquoted
-    expect(isEmail('?joe@apache.org')).toBeTruthy(); // ? is valid unquoted
-    expect(isEmail('&joe@apache.org')).toBeTruthy(); // & ditto
-    expect(isEmail('=joe@apache.org')).toBeTruthy(); // = ditto
-    expect(isEmail('+@apache.org')).toBeTruthy(); // + is valid unquoted
-    expect(isEmail('!@apache.org')).toBeTruthy(); // ! is valid unquoted
-    expect(isEmail('*@apache.org')).toBeTruthy(); // * is valid unquoted
-    expect(isEmail("'@apache.org")).toBeTruthy(); // ' is valid unquoted
-    expect(isEmail('%@apache.org')).toBeTruthy(); // % is valid unquoted
-    expect(isEmail('?@apache.org')).toBeTruthy(); // ? is valid unquoted
-    expect(isEmail('&@apache.org')).toBeTruthy(); // & ditto
-    expect(isEmail('=@apache.org')).toBeTruthy(); // = ditto
+  it("should pass Apache's EmailValidatorTest#testEmailUserName", async () => {
+    expect(isEmail('joe1blow@apache.org')).resolves.toBeTruthy();
+    expect(isEmail('joe$blow@apache.org')).resolves.toBeTruthy();
+    expect(isEmail('joe-@apache.org')).resolves.toBeTruthy();
+    expect(isEmail('joe_@apache.org')).resolves.toBeTruthy();
+    expect(isEmail('joe+@apache.org')).resolves.toBeTruthy(); // + is valid unquoted
+    expect(isEmail('joe!@apache.org')).resolves.toBeTruthy(); // ! is valid unquoted
+    expect(isEmail('joe*@apache.org')).resolves.toBeTruthy(); // * is valid unquoted
+    expect(isEmail("joe'@apache.org")).resolves.toBeTruthy(); // ' is valid unquoted
+    expect(isEmail('joe%45@apache.org')).resolves.toBeTruthy(); // % is valid unquoted
+    expect(isEmail('joe?@apache.org')).resolves.toBeTruthy(); // ? is valid unquoted
+    expect(isEmail('joe&@apache.org')).resolves.toBeTruthy(); // & ditto
+    expect(isEmail('joe=@apache.org')).resolves.toBeTruthy(); // = ditto
+    expect(isEmail('+joe@apache.org')).resolves.toBeTruthy(); // + is valid unquoted
+    expect(isEmail('!joe@apache.org')).resolves.toBeTruthy(); // ! is valid unquoted
+    expect(isEmail('*joe@apache.org')).resolves.toBeTruthy(); // * is valid unquoted
+    expect(isEmail("'joe@apache.org")).resolves.toBeTruthy(); // ' is valid unquoted
+    expect(isEmail('%joe45@apache.org')).resolves.toBeTruthy(); // % is valid unquoted
+    expect(isEmail('?joe@apache.org')).resolves.toBeTruthy(); // ? is valid unquoted
+    expect(isEmail('&joe@apache.org')).resolves.toBeTruthy(); // & ditto
+    expect(isEmail('=joe@apache.org')).resolves.toBeTruthy(); // = ditto
+    expect(isEmail('+@apache.org')).resolves.toBeTruthy(); // + is valid unquoted
+    expect(isEmail('!@apache.org')).resolves.toBeTruthy(); // ! is valid unquoted
+    expect(isEmail('*@apache.org')).resolves.toBeTruthy(); // * is valid unquoted
+    expect(isEmail("'@apache.org")).resolves.toBeTruthy(); // ' is valid unquoted
+    expect(isEmail('%@apache.org')).resolves.toBeTruthy(); // % is valid unquoted
+    expect(isEmail('?@apache.org')).resolves.toBeTruthy(); // ? is valid unquoted
+    expect(isEmail('&@apache.org')).resolves.toBeTruthy(); // & ditto
+    expect(isEmail('=@apache.org')).resolves.toBeTruthy(); // = ditto
 
     // UnQuoted Special characters are invalid
-    expect(isEmail('joe.@apache.org')).toBeFalsy(); // . not allowed at end of local part
-    expect(isEmail('.joe@apache.org')).toBeFalsy(); // . not allowed at start of local part
-    expect(isEmail('.@apache.org')).toBeFalsy(); // . not allowed alone
-    expect(isEmail('joe.ok@apache.org')).toBeTruthy(); // . allowed embedded
-    expect(isEmail('joe..ok@apache.org')).toBeFalsy(); // .. not allowed embedded
-    expect(isEmail('..@apache.org')).toBeFalsy(); // .. not allowed alone
-    expect(isEmail('joe(@apache.org')).toBeFalsy();
-    expect(isEmail('joe)@apache.org')).toBeFalsy();
-    expect(isEmail('joe,@apache.org')).toBeFalsy();
-    expect(isEmail('joe;@apache.org')).toBeFalsy();
+    expect(isEmail('joe.@apache.org')).resolves.toBeFalsy(); // . not allowed at end of local part
+    expect(isEmail('.joe@apache.org')).resolves.toBeFalsy(); // . not allowed at start of local part
+    expect(isEmail('.@apache.org')).resolves.toBeFalsy(); // . not allowed alone
+    expect(isEmail('joe.ok@apache.org')).resolves.toBeTruthy(); // . allowed embedded
+    expect(isEmail('joe..ok@apache.org')).resolves.toBeFalsy(); // .. not allowed embedded
+    expect(isEmail('..@apache.org')).resolves.toBeFalsy(); // .. not allowed alone
+    expect(isEmail('joe(@apache.org')).resolves.toBeFalsy();
+    expect(isEmail('joe)@apache.org')).resolves.toBeFalsy();
+    expect(isEmail('joe,@apache.org')).resolves.toBeFalsy();
+    expect(isEmail('joe;@apache.org')).resolves.toBeFalsy();
 
     // Quoted Special characters are valid
-    expect(isEmail('"joe."@apache.org')).toBeTruthy();
-    expect(isEmail('".joe"@apache.org')).toBeTruthy();
-    expect(isEmail('"joe+"@apache.org')).toBeTruthy();
-    expect(isEmail('"joe@"@apache.org')).toBeTruthy();
-    expect(isEmail('"joe!"@apache.org')).toBeTruthy();
-    expect(isEmail('"joe*"@apache.org')).toBeTruthy();
-    expect(isEmail('"joe\'"@apache.org')).toBeTruthy();
-    expect(isEmail('"joe("@apache.org')).toBeTruthy();
-    expect(isEmail('"joe)"@apache.org')).toBeTruthy();
-    expect(isEmail('"joe,"@apache.org')).toBeTruthy();
-    expect(isEmail('"joe%45"@apache.org')).toBeTruthy();
-    expect(isEmail('"joe;"@apache.org')).toBeTruthy();
-    expect(isEmail('"joe?"@apache.org')).toBeTruthy();
-    expect(isEmail('"joe&"@apache.org')).toBeTruthy();
-    expect(isEmail('"joe="@apache.org')).toBeTruthy();
-    expect(isEmail('".."@apache.org')).toBeTruthy();
+    expect(isEmail('"joe."@apache.org')).resolves.toBeTruthy();
+    expect(isEmail('".joe"@apache.org')).resolves.toBeTruthy();
+    expect(isEmail('"joe+"@apache.org')).resolves.toBeTruthy();
+    expect(isEmail('"joe@"@apache.org')).resolves.toBeTruthy();
+    expect(isEmail('"joe!"@apache.org')).resolves.toBeTruthy();
+    expect(isEmail('"joe*"@apache.org')).resolves.toBeTruthy();
+    expect(isEmail('"joe\'"@apache.org')).resolves.toBeTruthy();
+    expect(isEmail('"joe("@apache.org')).resolves.toBeTruthy();
+    expect(isEmail('"joe)"@apache.org')).resolves.toBeTruthy();
+    expect(isEmail('"joe,"@apache.org')).resolves.toBeTruthy();
+    expect(isEmail('"joe%45"@apache.org')).resolves.toBeTruthy();
+    expect(isEmail('"joe;"@apache.org')).resolves.toBeTruthy();
+    expect(isEmail('"joe?"@apache.org')).resolves.toBeTruthy();
+    expect(isEmail('"joe&"@apache.org')).resolves.toBeTruthy();
+    expect(isEmail('"joe="@apache.org')).resolves.toBeTruthy();
+    expect(isEmail('".."@apache.org')).resolves.toBeTruthy();
 
     // escaped quote character valid in quoted string
-    expect(isEmail('"john\\"doe"@apache.org')).toBeTruthy();
+    expect(isEmail('"john\\"doe"@apache.org')).resolves.toBeTruthy();
     expect(
       isEmail(
         'john56789.john56789.john56789.john56789.john56789.john56789.john@example.com',
       ),
-    ).toBeTruthy();
+    ).resolves.toBeTruthy();
     expect(
       isEmail(
         'john56789.john56789.john56789.john56789.john56789.john56789.john5@example.com',
       ),
-    ).toBeFalsy();
+    ).resolves.toBeFalsy();
     expect(
       isEmail('\\>escape\\\\special\\^characters\\<@example.com'),
-    ).toBeTruthy();
-    expect(isEmail('Abc\\@def@example.com')).toBeTruthy();
-    expect(isEmail('Abc@def@example.com')).toBeFalsy();
-    expect(isEmail('space\\ monkey@example.com')).toBeTruthy();
+    ).resolves.toBeTruthy();
+    expect(isEmail('Abc\\@def@example.com')).resolves.toBeTruthy();
+    expect(isEmail('Abc@def@example.com')).resolves.toBeFalsy();
+    expect(isEmail('space\\ monkey@example.com')).resolves.toBeTruthy();
   });
 
-  // Test disabled as algorithm is same as Apache's, which fails too (VALIDATOR-267)
-  it.skip("should pass Apache's EmailValidatorTest#testEmailFromPerl", () => {
-    expect(isEmail('abigail@example.com')).toBeTruthy();
-    expect(isEmail('abigail@example.com ')).toBeTruthy();
-    expect(isEmail(' abigail@example.com')).toBeTruthy();
-    expect(isEmail('abigail @example.com ')).toBeTruthy();
-    expect(isEmail('*@example.net')).toBeTruthy();
-    expect(isEmail('"\\""@foo.bar')).toBeTruthy();
-    expect(isEmail('fred&barny@example.com')).toBeTruthy();
-    expect(isEmail('---@example.com')).toBeTruthy();
-    expect(isEmail('foo-bar@example.net')).toBeTruthy();
-    expect(isEmail('"127.0.0.1"@[127.0.0.1]')).toBeTruthy();
-    expect(isEmail('Abigail <abigail@example.com>')).toBeTruthy();
-    expect(isEmail('Abigail<abigail@example.com>')).toBeTruthy();
-    expect(isEmail('Abigail<@a,@b,@c:abigail@example.com>')).toBeTruthy();
-    expect(isEmail('"This is a phrase"<abigail@example.com>')).toBeTruthy();
-    expect(isEmail('"Abigail "<abigail@example.com>')).toBeTruthy();
-    expect(isEmail('"Joe & J. Harvey" <example @Org>')).toBeTruthy();
-    expect(isEmail('Abigail <abigail @ example.com>')).toBeTruthy();
-    expect(
-      isEmail('Abigail made this <  abigail   @   example  .    com    >'),
-    ).toBeTruthy();
-    expect(isEmail('Abigail(the bitch)@example.com')).toBeTruthy();
-    expect(isEmail('Abigail <abigail @ example . (bar) com >')).toBeTruthy();
-    expect(
-      isEmail(
-        'Abigail < (one)  abigail (two) @(three)example . (bar) com (quz) >',
-      ),
-    ).toBeTruthy();
-    expect(
-      isEmail(
-        'Abigail (foo) (((baz)(nested) (comment)) ! ) < (one)  abigail (two) @(three)example . (bar) com (quz) >',
-      ),
-    ).toBeTruthy();
-    expect(isEmail('Abigail <abigail(fo\\(o)@example.com>')).toBeTruthy();
-    expect(isEmail('Abigail <abigail(fo\\)o)@example.com> ')).toBeTruthy();
-    expect(isEmail('(foo) abigail@example.com')).toBeTruthy();
-    expect(isEmail('abigail@example.com (foo)')).toBeTruthy();
-    expect(isEmail('"Abi\\"gail" <abigail@example.com>')).toBeTruthy();
-    expect(isEmail('abigail@[example.com]')).toBeTruthy();
-    expect(isEmail('abigail@[exa\\[ple.com]')).toBeTruthy();
-    expect(isEmail('abigail@[exa\\]ple.com]')).toBeTruthy();
-    expect(isEmail('":sysmail"@  Some-Group. Some-Org')).toBeTruthy();
-    expect(
-      isEmail('Muhammed.(I am  the greatest) Ali @(the)Vegas.WBA'),
-    ).toBeTruthy();
-    expect(isEmail('mailbox.sub1.sub2@this-domain')).toBeTruthy();
-    expect(isEmail('sub-net.mailbox@sub-domain.domain')).toBeTruthy();
-    expect(isEmail('name:;')).toBeTruthy();
-    expect(isEmail("':;")).toBeTruthy();
-    expect(isEmail('name:   ;')).toBeTruthy();
-    expect(isEmail('Alfred Neuman <Neuman@BBN-TENEXA>')).toBeTruthy();
-    expect(isEmail('Neuman@BBN-TENEXA')).toBeTruthy();
-    expect(isEmail('"George, Ted" <Shared@Group.Arpanet>')).toBeTruthy();
-    expect(isEmail('Wilt . (the  Stilt) Chamberlain@NBA.US')).toBeTruthy();
-    expect(isEmail('Cruisers:  Port@Portugal, Jones@SEA;')).toBeTruthy();
-    expect(isEmail('$@[]')).toBeTruthy();
-    expect(isEmail('*()@[]')).toBeTruthy();
-    expect(
-      isEmail('"quoted ( brackets" ( a comment )@example.com'),
-    ).toBeTruthy();
-    expect(
-      isEmail('"Joe & J. Harvey"\\x0D\\x0A     <ddd\\@ Org>'),
-    ).toBeTruthy();
-    expect(isEmail('"Joe &\\x0D\\x0A J. Harvey" <ddd \\@ Org>')).toBeTruthy();
-    expect(
-      isEmail(
-        'Gourmets:  Pompous Person <WhoZiWhatZit\\@Cordon-Bleu>,\\x0D\\x0A' +
-          '        Childs\\@WGBH.Boston, "Galloping Gourmet"\\@\\x0D\\x0A' +
-          '        ANT.Down-Under (Australian National Television),\\x0D\\x0A' +
-          '        Cheapie\\@Discount-Liquors;',
-      ),
-    ).toBeTruthy();
-    expect(isEmail('   Just a string')).toBeFalsy();
-    expect(isEmail('string')).toBeFalsy();
-    expect(isEmail('(comment)')).toBeFalsy();
-    expect(isEmail('()@example.com')).toBeFalsy();
-    expect(isEmail('fred(&)barny@example.com')).toBeFalsy();
-    expect(isEmail('fred\\ barny@example.com')).toBeFalsy();
-    expect(isEmail('Abigail <abi gail @ example.com>')).toBeFalsy();
-    expect(isEmail('Abigail <abigail(fo(o)@example.com>')).toBeFalsy();
-    expect(isEmail('Abigail <abigail(fo)o)@example.com>')).toBeFalsy();
-    expect(isEmail('"Abi"gail" <abigail@example.com>')).toBeFalsy();
-    expect(isEmail('abigail@[exa]ple.com]')).toBeFalsy();
-    expect(isEmail('abigail@[exa[ple.com]')).toBeFalsy();
-    expect(isEmail('abigail@[exaple].com]')).toBeFalsy();
-    expect(isEmail('abigail@')).toBeFalsy();
-    expect(isEmail('@example.com')).toBeFalsy();
-    expect(
-      isEmail('phrase: abigail@example.com abigail@example.com ;'),
-    ).toBeFalsy();
-    expect(isEmail('invalid�char@example.com')).toBeFalsy();
+  it("should pass Apache's EmailValidatorTest#testValidator293", async () => {
+    expect(isEmail('abc-@abc.com')).resolves.toBeTruthy();
+    expect(isEmail('abc_@abc.com')).resolves.toBeTruthy();
+    expect(isEmail('abc-def@abc.com')).resolves.toBeTruthy();
+    expect(isEmail('abc_def@abc.com')).resolves.toBeTruthy();
+    expect(isEmail('abc@abc_def.com')).resolves.toBeFalsy();
   });
 
-  it("should pass Apache's EmailValidatorTest#testValidator293", () => {
-    expect(isEmail('abc-@abc.com')).toBeTruthy();
-    expect(isEmail('abc_@abc.com')).toBeTruthy();
-    expect(isEmail('abc-def@abc.com')).toBeTruthy();
-    expect(isEmail('abc_def@abc.com')).toBeTruthy();
-    expect(isEmail('abc@abc_def.com')).toBeFalsy();
-  });
-
-  it("should pass Apache's EmailValidaotrTest#testValidator365", () => {
+  it("should pass Apache's EmailValidaotrTest#testValidator365", async () => {
     expect(
       isEmail(
         'Loremipsumdolorsitametconsecteturadipiscingelit.Nullavitaeligulamattisrhoncusnuncegestasmattisleo.' +
@@ -324,24 +228,24 @@ describe('email validator', () => {
           'Etiamnisinislvenenatisvelauctorutullamcorperinjusto.Proinvelligulaerat.Phasellusvestibulumgravidamassanonfeugiat.' +
           'Maecenaspharetraeuismodmetusegetefficitur.Suspendisseamet@gmail.com',
       ),
-    ).toBeFalsy();
+    ).resolves.toBeFalsy();
   });
 
-  it("should pass Apache's EmailValidatorTest#testEmailAtTLD", () => {
-    expect(isEmail('test@com', false, true)).toBeTruthy();
+  it("should pass Apache's EmailValidatorTest#testEmailAtTLD", async () => {
+    expect(isEmail('test@com', false, true)).resolves.toBeTruthy();
   });
 
-  it("should pass Apache's EmailValidatorTest#testValidator359", () => {
-    expect(isEmail('abc@.com', false, true)).toBeFalsy();
+  it("should pass Apache's EmailValidatorTest#testValidator359", async () => {
+    expect(isEmail('abc@.com', false, true)).resolves.toBeFalsy();
   });
 
-  it("should pass Apache's EmailValidatorTest#testValidator374", () => {
-    expect(isEmail('abc@school.school')).toBeTruthy();
+  it("should pass Apache's EmailValidatorTest#testValidator374", async () => {
+    expect(isEmail('abc@school.school')).resolves.toBeTruthy();
   });
 
-  it('should return false if email is empty', () => {
-    expect(isEmail('')).toBeFalsy();
-    expect(isEmail(null)).toBeFalsy();
-    expect(isEmail(undefined)).toBeFalsy();
+  it('should return false if email is empty', async () => {
+    expect(isEmail('')).resolves.toBeFalsy();
+    expect(isEmail(null)).resolves.toBeFalsy();
+    expect(isEmail(undefined)).resolves.toBeFalsy();
   });
 });

--- a/test/isTld.test.ts
+++ b/test/isTld.test.ts
@@ -5,7 +5,7 @@ import isTld, {
 } from '../src/isTld';
 
 describe('tld validator', () => {
-  it("should pass Apache's DomainValidatorTest#testTopLevelDomains", () => {
+  it("should pass Apache's DomainValidatorTest#testTopLevelDomains", async () => {
     // infrastructure TLDs
     expect(isInfrastructureTld('.arpa')).toBeTruthy();
     expect(isInfrastructureTld('.com')).toBeFalsy();
@@ -19,12 +19,16 @@ describe('tld validator', () => {
     expect(isCountryCodeTld('.org')).toBeFalsy();
 
     // case-insensitive TLDs
-    expect(isTld('.COM')).toBeTruthy();
-    expect(isTld('.BiZ')).toBeTruthy();
+    expect(isTld('.COM')).resolves.toBeTruthy();
+    expect(isTld('.BiZ')).resolves.toBeTruthy();
+
+    // punycode
+    expect(isTld('.xn--p1ai')).resolves.toBeTruthy();
+    expect(isTld('.\uFFFD')).resolves.toBeFalsy();
 
     // corner cases
-    expect(isTld('.nope')).toBeFalsy(); // this isn't guarenteed forever
-    expect(isTld('')).toBeFalsy();
-    expect(isTld(null)).toBeFalsy();
+    expect(isTld('.nope')).resolves.toBeFalsy(); // this isn't guarenteed forever
+    expect(isTld('')).resolves.toBeFalsy();
+    expect(isTld(null)).resolves.toBeFalsy();
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "esnext",
-    "target": "es2016",
+    "target": "es2017",
     "declaration": true,
     "declarationDir": "./tsc/types",
     "moduleResolution": "node",


### PR DESCRIPTION
Node.js has `url`, browsers automatically convert unicode in `<a>` elements. Since this module should work for front end and backend, dynamic import and async is the way to go. Minimum ES8 (2017)

Tests now also run twice, once in `node` and once in `jsdom`, to make sure everything works in node and browser